### PR TITLE
Kubernetes intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+/kubernetes-intro/web/microservices-demo/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# chombo_platform
-chombo Platform repository
+# Выполнено ДЗ № 1
+
+ - [ ] Основное ДЗ
+ - Разберитесь почему все pod в namespace kube-system восстановились
+после удаления. Укажите причину в описании PR
+
+``` sh 
+~ % kubectl get pods -n kube-system
+coredns-64897985d-5j8jn            1/1     Running   0          40m
+etcd-minikube                      1/1     Running   3          40m
+kube-apiserver-minikube            1/1     Running   3          40m
+kube-controller-manager-minikube   1/1     Running   3          40m
+kube-proxy-thcpm                   1/1     Running   0          40m
+kube-scheduler-minikube            1/1     Running   3          40m
+```
+[static Pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/): 
+*kube-apiserver-minikube, kube-controller-manager-minikube, 
+kube-controller-manager-minikube, kube-proxy-thcpm, kube-scheduler-minikube*
+restarted by **kubelet**
+
+[ReplicationController](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller)
+*coredns-64897985d-5j8jn*
+```
+spec:
+  replicas: 1
+```
+
+ - [ ] Задание со *
+   - Выясните причину, по которой pod frontend находится в статусе Error
+ ```
+{"message":"Tracing enabled.","severity":"info","timestamp":"2022-03-29T21:31:48.429464968Z"}
+{"message":"Profiling enabled.","severity":"info","timestamp":"2022-03-29T21:31:48.429514385Z"}
+panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
+```
+   - Создайте новый манифест  . При его
+   применении ошибка должна исчезнуть. Подсказки можно найти:
+   В логах - kubectl logs frontend
+   В манифесте по
+   В результате, после применения исправленного манифеста pod
+   frontend должен находиться в статусе Running (опустим вопрос,
+   действительно ли микросервис работает)
+
+## В процессе сделано:
+ - описан Dockerfile для запуска nginx пользователя с UID 1001, 
+ и выполнено минимальное конфгурирование nginx (listen port 8000, host root /app)
+ - образ залит в личный регистри dochombo/otus:web.v1
+ - установлен kubectl
+ - развёрнут кластер Minikube, проведена проверка устойчивости работы 
+кастара поднятого по умолчанию *(docker rm -f $(docker ps -a -q))*
+ - изучены инструкции kubectl 
+
+``` 
+kubectl apply -f <file>
+kubectl get pod <name> -o yaml
+kubectl describe pod <name>
+kubectl delete pod <name>
+kubectl get pods -w
+kubectl port-forward --address 0.0.0.0 pod/<name> port:port
+...
+использования ad-hoc режима
+```
+ - найден ответ на вопрос о причинах восстановления pod в kube-system namespace
+ - созданы манифесты *web-pod.yaml, frontend-pod-healthy.yaml*
+
+## Как запустить проект:
+ - ...
+
+## Как проверить работоспособность:
+ - ...
+
+## PR checklist:
+ - [ kubernetes-intro ] Выставлен label с темой домашнего задания

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+    version: v1
+    run: frontend
+spec:
+  containers:
+    - name: frontend
+      image: dochombo/otus:frontend.v1
+      imagePullPolicy: Always
+      env:
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+      # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+      # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
+      # - name: ENV_PLATFORM
+      #   value: "aws"
+      - name: DISABLE_TRACING
+        value: "1"
+      - name: DISABLE_PROFILER
+        value: "1"
+      # - name: JAEGER_SERVICE_ADDR
+      #   value: "jaeger-collector:14268"
+      # - name: CYMBAL_BRANDING
+      #   value: "true"
+      resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml.dist
+++ b/kubernetes-intro/frontend-pod.yaml.dist
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: app-frontend
+  name: app-frontend
+spec:
+  containers:
+  - image: dochombo/otus:frontend.v1
+    name: app-frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    image: dochombo/otus:web.v1
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init-web
+    image: busybox:1.34.1
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: app
+      mountPath: /app
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/.dockerignore
+++ b/kubernetes-intro/web/.dockerignore
@@ -1,0 +1,4 @@
+.idea
+.git
+.cache
+.gitignore

--- a/kubernetes-intro/web/.dockerignore
+++ b/kubernetes-intro/web/.dockerignore
@@ -2,3 +2,5 @@
 .git
 .cache
 .gitignore
+microservices-demo
+

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -15,44 +15,45 @@ RUN set -x; \
     touch /var/run/nginx.pid; \
     chown -R nginx:nginx /var/run/nginx.pid; \
     rm /etc/nginx/conf.d/default.conf; \
-    mkdir /app ; \
+    mkdir /app; \
+    chown -R nginx:nginx /app; \
     { \
     echo 'server {'; \
     echo '    listen 8000;'; \
-    echo '    server_name localhost;'; \
-    echo '    root /usr/share/nginx/html;'; \
+    echo '    root /app;'; \
     echo '    index index.html index.htm;'; \
     echo; \
     echo '    location /healthcheck {'; \
     echo '        return 200;'; \
     echo '        access_log off;'; \
-    echo '        allow 127.0.0.1/32;'; \
-    echo '        deny all;'; \
+    echo '        #allow 127.0.0.1/32;'; \
+    echo '        #deny all;'; \
     echo '    }'; \
     echo; \
     echo '    location /status {'; \
     echo '        stub_status on;'; \
     echo '        access_log off;'; \
-    echo '        allow 127.0.0.1/32;'; \
-    echo '        deny all;'; \
+    echo '        #allow 127.0.0.1/32;'; \
+    echo '        #deny all;'; \
     echo '    }'; \
     echo; \
     echo '    location / {'; \
-    echo '        alias   /app/;'; \
+    echo '        try_files $uri $uri/ =404;'; \
     echo '    }'; \
     echo; \
-    echo '    location ~ /\. {'; \
-    echo '        deny all;'; \
-    echo '        access_log off;'; \
-    echo '        log_not_found off;'; \
-    echo '    }'; \
+    echo '    #location ~ /\. {'; \
+    echo '    #    deny all;'; \
+    echo '    #    access_log off;'; \
+    echo '    #    log_not_found off;'; \
+    echo '    #}'; \
     echo; \
-    echo '    error_page   500 502 503 504  /50x.html;'; \
-    echo '    location = /50x.html {'; \
-    echo '        root   /usr/share/nginx/html;'; \
-    echo '    }'; \
+    echo '    #error_page   500 502 503 504  /50x.html;'; \
+    echo '    #location = /50x.html {'; \
+    echo '    #    root   /usr/share/nginx/html;'; \
+    echo '    #}'; \
     echo '}'; \
 	  } | tee /etc/nginx/conf.d/01-host.conf
 
 USER ${USER}
 WORKDIR /app
+EXPOSE 8000

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -20,37 +20,12 @@ RUN set -x; \
     { \
     echo 'server {'; \
     echo '    listen 8000;'; \
+    echo '    server_name _;'; \
     echo '    root /app;'; \
     echo '    index index.html index.htm;'; \
-    echo; \
-    echo '    location /healthcheck {'; \
-    echo '        return 200;'; \
-    echo '        access_log off;'; \
-    echo '        #allow 127.0.0.1/32;'; \
-    echo '        #deny all;'; \
-    echo '    }'; \
-    echo; \
-    echo '    location /status {'; \
-    echo '        stub_status on;'; \
-    echo '        access_log off;'; \
-    echo '        #allow 127.0.0.1/32;'; \
-    echo '        #deny all;'; \
-    echo '    }'; \
-    echo; \
     echo '    location / {'; \
     echo '        try_files $uri $uri/ =404;'; \
     echo '    }'; \
-    echo; \
-    echo '    #location ~ /\. {'; \
-    echo '    #    deny all;'; \
-    echo '    #    access_log off;'; \
-    echo '    #    log_not_found off;'; \
-    echo '    #}'; \
-    echo; \
-    echo '    #error_page   500 502 503 504  /50x.html;'; \
-    echo '    #location = /50x.html {'; \
-    echo '    #    root   /usr/share/nginx/html;'; \
-    echo '    #}'; \
     echo '}'; \
 	  } | tee /etc/nginx/conf.d/01-host.conf
 

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,58 @@
+FROM nginx:1.20.2-alpine
+
+ENV GID=1001 \
+    UID=1001 \
+    USER=nginx \
+    GROUP=nginx
+
+RUN set -x; \
+    deluser ${USER}; \
+    addgroup -g ${GID} -S ${GROUP}; \
+    adduser -S -D -H -u ${UID} -h /var/cache/nginx -s /sbin/nologin -G ${GROUP} -g ${GROUP} ${USER}; \
+    chown -R nginx:nginx /var/cache/nginx; \
+    chown -R nginx:nginx /var/log/nginx; \
+    chown -R nginx:nginx /etc/nginx/conf.d; \
+    touch /var/run/nginx.pid; \
+    chown -R nginx:nginx /var/run/nginx.pid; \
+    rm /etc/nginx/conf.d/default.conf; \
+    mkdir /app ; \
+    { \
+    echo 'server {'; \
+    echo '    listen 8000;'; \
+    echo '    server_name localhost;'; \
+    echo '    root /usr/share/nginx/html;'; \
+    echo '    index index.html index.htm;'; \
+    echo; \
+    echo '    location /healthcheck {'; \
+    echo '        return 200;'; \
+    echo '        access_log off;'; \
+    echo '        allow 127.0.0.1/32;'; \
+    echo '        deny all;'; \
+    echo '    }'; \
+    echo; \
+    echo '    location /status {'; \
+    echo '        stub_status on;'; \
+    echo '        access_log off;'; \
+    echo '        allow 127.0.0.1/32;'; \
+    echo '        deny all;'; \
+    echo '    }'; \
+    echo; \
+    echo '    location / {'; \
+    echo '        alias   /app/;'; \
+    echo '    }'; \
+    echo; \
+    echo '    location ~ /\. {'; \
+    echo '        deny all;'; \
+    echo '        access_log off;'; \
+    echo '        log_not_found off;'; \
+    echo '    }'; \
+    echo; \
+    echo '    error_page   500 502 503 504  /50x.html;'; \
+    echo '    location = /50x.html {'; \
+    echo '        root   /usr/share/nginx/html;'; \
+    echo '    }'; \
+    echo '}'; \
+	  } | tee /etc/nginx/conf.d/01-host.conf
+
+USER ${USER}
+WORKDIR /app


### PR DESCRIPTION
# Выполнено ДЗ № 1

 - [ ] Основное ДЗ
 - Разберитесь почему все pod в namespace kube-system восстановились
после удаления. Укажите причину в описании PR

``` sh 
~ % kubectl get pods -n kube-system
coredns-64897985d-5j8jn            1/1     Running   0          40m
etcd-minikube                      1/1     Running   3          40m
kube-apiserver-minikube            1/1     Running   3          40m
kube-controller-manager-minikube   1/1     Running   3          40m
kube-proxy-thcpm                   1/1     Running   0          40m
kube-scheduler-minikube            1/1     Running   3          40m
```
[static Pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/): 
*kube-apiserver-minikube, kube-controller-manager-minikube, 
kube-controller-manager-minikube, kube-proxy-thcpm, kube-scheduler-minikube*
restarted by **kubelet**

[ReplicationController](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller)
*coredns-64897985d-5j8jn*
```
spec:
  replicas: 1
```

 - [ ] Задание со *
   - Выясните причину, по которой pod frontend находится в статусе Error
 ```
{"message":"Tracing enabled.","severity":"info","timestamp":"2022-03-29T21:31:48.429464968Z"}
{"message":"Profiling enabled.","severity":"info","timestamp":"2022-03-29T21:31:48.429514385Z"}
panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
```
   - Создайте новый манифест  . При его
   применении ошибка должна исчезнуть. Подсказки можно найти:
   В логах - kubectl logs frontend
   В манифесте по
   В результате, после применения исправленного манифеста pod
   frontend должен находиться в статусе Running (опустим вопрос,
   действительно ли микросервис работает)

## В процессе сделано:
 - описан Dockerfile для запуска nginx пользователя с UID 1001, 
 и выполнено минимальное конфгурирование nginx (listen port 8000, host root /app)
 - образ залит в личный регистри dochombo/otus:web.v1
 - установлен kubectl
 - развёрнут кластер Minikube, проведена проверка устойчивости работы 
кастара поднятого по умолчанию *(docker rm -f $(docker ps -a -q))*
 - изучены инструкции kubectl 

``` 
kubectl apply -f <file>
kubectl get pod <name> -o yaml
kubectl describe pod <name>
kubectl delete pod <name>
kubectl get pods -w
kubectl port-forward --address 0.0.0.0 pod/<name> port:port
...
использования ad-hoc режима
```
 - найден ответ на вопрос о причинах восстановления pod в kube-system namespace
 - созданы манифесты *web-pod.yaml, frontend-pod-healthy.yaml*

## Как запустить проект:
 - ...

## Как проверить работоспособность:
 - ...

## PR checklist:
 - [ kubernetes-intro ] Выставлен label с темой домашнего задания
