### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: dochombo/otus:frontend.v1
+        imagePullPolicy: IfNotPresent
+#        ports:
+#        - containerPort: 8080
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+#        livenessProbe:
+#          initialDelaySeconds: 10
+#          httpGet:
+#            path: "/_healthz"
+#            port: 8080
+#            httpHeaders:
+#            - name: "Cookie"
+#              value: "shop_session-id=x-liveness-probe"
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: dochombo/otus:frontend.v2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: node-exporter
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - args:
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        name: node-exporter
+        image: prom/node-exporter
+        ports:
+          - containerPort: 9100
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: dochombo/otus:paymentservice.v2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: dochombo/otus:paymentservice.v2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: dochombo/otus:paymentservice.v2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
+###maxSurge и maxUnavailable

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: dochombo/otus:paymentservice.v1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -28,18 +28,10 @@ spec:
         value: "checkoutservice:5050"
       - name: AD_SERVICE_ADDR
         value: "adservice:9555"
-      # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
-      # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
-      # - name: ENV_PLATFORM
-      #   value: "aws"
       - name: DISABLE_TRACING
         value: "1"
       - name: DISABLE_PROFILER
         value: "1"
-      # - name: JAEGER_SERVICE_ADDR
-      #   value: "jaeger-collector:14268"
-      # - name: CYMBAL_BRANDING
-      #   value: "true"
       resources: {}
   dnsPolicy: ClusterFirst
   restartPolicy: Never


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [ ] Основное ДЗ
 - Удалите все запущенные pod и после их пересоздания еще раз
   проверьте, из какого образа они развернулись
   Руководствуясь материалами лекции опишите произошедшую
   ситуацию, почему обновление ReplicaSet не повлекло обновление
   запущенных pod?
```   
chombo@% kubectl delete pods -l app=frontend
pod "frontend-dpnkg" deleted
pod "frontend-nhlgm" deleted
pod "frontend-sk8rf" deleted
chombo@% kubectl get pods -l app=frontend -o=jsonpath='{.items[0:3].spec.containers[0].image}'
dochombo/otus:frontend.v2 dochombo/otus:frontend.v2 dochombo/otus:frontend.v2%
```
контроллер ReplicaSet следит за количеством запущенных подов,
но не за их «качеством». Для применения необходимо создать 
ReplicaSet с новой конфигураций, затем уменьшаем replicas в 
старом и увеличивить replicas в новом.


 - [ ] Задание со *
   С использованием параметров maxSurge и maxUnavailable
   самостоятельно реализуйте два следующих сценария
   развертывания: blue-green, Rolling Update.
   paymentservice-deployment-bg.yaml
```
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 3
```
   paymentservice-deployment-reverse.yaml
```  
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
      maxSurge: 0
```

 - DaemonSet для Node Exporter на всех нодах
```
      tolerations:
      - key: node-role.kubernetes.io/master
        operator: Exists
        effect: NoSchedule
```

## PR checklist:
 - [ kubernetes-controllers ] Выставлен label с темой домашнего задания
