### PR TITLE
Kubernetes operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,157 @@
-# Выполнено ДЗ № 5
+# Выполнено ДЗ № 7
 
- - [ ] Основное ДЗ
-   Volumes, Storages, StatefulSet, Secret
+- [ ] Основное ДЗ
+
+Примеры локальных экспеременентов  kubernetes-operators/m1_deploy
 ```
-└── kubernetes-volumes
-    ├── minio-headless-service.yaml
-    ├── minio-mysecret.yaml
-    └── minio-statefulset.yaml
+├── kubernetes-operators
+│   ├── build
+│   │   ├── Dockerfile
+│   │   ├── mysql-operator.py
+│   │   └── templates
+│   │       ├── backup-job.yml.j2
+│   │       ├── backup-pv.yml.j2
+│   │       ├── backup-pvc.yml.j2
+│   │       ├── mysql-deployment.yml.j2
+│   │       ├── mysql-pv.yml.j2
+│   │       ├── mysql-pvc.yml.j2
+│   │       ├── mysql-service.yml.j2
+│   │       └── restore-job.yml.j2
+│   ├── deploy
+│   │   ├── ClusterRoleBinding.yml
+│   │   ├── cr.yml
+│   │   ├── crd.yml
+│   │   ├── deploy-operator.yml
+│   │   ├── role.yml
+│   │   └── service-account.yml
+│   └── m1_deploy
+│       ├── cr.yml
+│       └── crd.yml
+
+```
+С момента описание схемы выполнения ДЗ произошли изменения:
+m1_deploy/crd.yml
+```
+#The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22.
+#https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+
+```
+
+Отладка контроллер - при использовании для примера приложенного к домашнему заданию контроллера
+были исправлены следующее
+
+```
+#load() missing 1 required positional argument: 'Loader'", 'subrefs
+- json_manifest = yaml.load(yaml_manifest)
++ json_manifest = yaml.safe_load(sys.stdin)
+```
+
+```
+#'это не обязательно, по факту в шаблоне указано явно, как задел а будущее
+- backup_pv = render_template('backup-pv.yml.j2', {'name': name})
++ backup_pv = render_template('backup-pv.yml.j2', {'name': name, 'storage_size': storage_size})
+
+- backup_pvc = render_template('backup-pvc.yml.j2', {'name': name)
++ backup_pvc = render_template('backup-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+```
+
+Так как домашнее задание выполняется на m1, возникли сложности и образом
+mysql:5.7, в процессе локальной отладки использовался arm64v8/mysql:8.0.29-oracle.
+
+build/templates/mysql-deployment.yml.j2
+```
+- args:
+- - "--ignore-db-dir=lost+found"
+```
+Вероятнее всего при автотестах не заработает, ограниченное свободное время
+на выполнение ДЗ - не позволит сделать его в полном обьеме, так что частично
+придется ограничиться тестовыми пояснениями
+
+Еще одной неприятной и не решенной проблемой - оказалась необходимость руками
+удалять mysql-instance-pv.
+```
+[2022-05-18 19:51:42,187] kopf.objects         [WARNING ] [default/mysql-instance] Patching failed with inconsistencies: (('remove', ('status',), {'kopf': {'progress': 
+{'mysql_on_create': {'started': '2022-05-18T16:51:42.120697', 'stopped': None, 'delayed': '2022-05-18T16:52:42.175612', 'purpose': 'create', 'retries': 1, 'success': 
+False, 'failure': False, 'message': '(409)\nReason: Conflict\nHTTP response headers: HTTPHeaderDict({\'Audit-Id\': \'70b1402d-5889-4c81-8ae8-d4e078b58a5c\', \'Cache-Control\': \'no-cache, private\', \'Content-Type\': 
+\'application/json\', \'X-Kubernetes-Pf-Flowschema-Uid\': \'b41bfecc-8ad1-4996-ab2d-bc0acd241368\', \'X-Kubernetes-Pf-Prioritylevel-Uid\': \'dfab7d6d-35c9-4382-bf9b-a48d4bc1daee\', \'Date\': 
+\'Wed, 18 May 2022 16:51:42 GMT\', \'Content-Length\': \'238\'})\nHTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"persistentvolumes \\"mysql-instance-pv\\" already exists",
+"reason":"AlreadyExists","details":{"name":"mysql-instance-pv","kind":"persistentvolumes"},"code":409}\n\n', 'subrefs': None}}}}, None),)
+
+```
+
+- [ ] Задание со * (1)
+
+- Исправить контроллер, чтобы он писал в status subresource
+- Описать изменения в README.md (показать код, объяснить, что он делает)
+- В README показать, что в status происходит запись
+- Например, при успешном создании mysql-instance, kubectl describe
+  mysqls.otus.homework mysql-instance может показывать:
+
+m1_deploy/crd.yml
+``` 
+            status:
+              type: object
+              properties:
+                describe:
+                  type: string
+      subresources:
+        status: {}
+```
+~/Library/Python/3.8/bin/kopf run mysql-operator.py
+```
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+def set_status_describe(spec, patch, **kwargs):
+    patch.status['describe'] = 'describe it'
+ ```
+
+kubectl describe mysqls.otus.homework mysql-instance
+
+```
+Spec:
+  Database:      otus-database
+  Image:         arm64v8/mysql:8.0.29-oracle
+  Password:      otuspassword
+  storage_size:  1Gi
+Status:
+  Describe:  describe it
+Events:
+  Type    Reason   Age   From  Message
+  ----    ------   ----  ----  -------
+  Normal  Logging  23s   kopf  Handler 'set_status_describe' succeeded.
+  Normal  Logging  23s   kopf  Creation is processed: 2 succeeded; 0 failed.
+  Normal  Logging  23s   kopf  Handler 'mysql_on_create' succeeded.
+```
+
+- [ ] Задание со * (2)
+  В задании предложено реализовать изменений пароля (в случае с предложенным в задании вариантом
+  дополнительно надо было бы создать шаблон job и выполнить похожие
+  действия как описаны в mysql_on_create)
+  Реализация была сознательно упрощена, в случае изменения
+  spec.field записывается status.describe:
+
+m1_deploy/cr.yml
+```
+  field: field2
+```
+m1_deploy/crd.yml
+```
+                field:
+                  type: string
+```
+kubectl describe mysqls.otus.homework mysql-instance
+```
+Status:
+  Describe:  old:field1; new:field2
+Events:
+  Type    Reason   Age   From  Message
+  ----    ------   ----  ----  -------
+  Normal  Logging  16s   kopf  Updating is processed: 1 succeeded; 0 failed.
+  Normal  Logging  16s   kopf  Handler 'update_field/spec.field' succeeded.
 ```
 
 ## PR checklist:
- - [ kubernetes-volumes ] Выставлен label с темой домашнего задания
+- [ kubernetes-operators ] Выставлен label с темой домашнего задания
+
+

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -6,20 +6,26 @@ metadata:
     app: web
 spec:
   containers:
-  - name: web
-    image: dochombo/otus:web.v1
-    imagePullPolicy: Always
-    volumeMounts:
-    - name: app
-      mountPath: /app
+    - name: web
+      image: dochombo/otus:web.v1
+      imagePullPolicy: Always
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 8000
+      livenessProbe:
+        tcpSocket: { port: 8000 }
+      volumeMounts:
+        - name: app
+          mountPath: /app
   initContainers:
-  - name: init-web
-    image: busybox:1.34.1
-    imagePullPolicy: IfNotPresent
-    volumeMounts:
-    - name: app
-      mountPath: /app
-    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    - name: init-web
+      image: busybox:1.34.1
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - name: app
+          mountPath: /app
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
   volumes:
     - name: app
       emptyDir: {}

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/metallb-system/metallb.yaml
+++ b/kubernetes-networks/metallb-system/metallb.yaml
@@ -1,0 +1,392 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  - SYS_ADMIN
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: false
+  hostNetwork: true
+  hostPID: false
+  hostPorts:
+  - max: 7472
+    min: 7472
+  privileged: true
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - policy
+  resourceNames:
+  - controller
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - policy
+  resourceNames:
+  - speaker
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-lister
+subjects:
+- kind: ServiceAccount
+  name: speaker
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: speaker
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: METALLB_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METALLB_ML_BIND_ADDR
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: METALLB_ML_LABELS
+          value: "app=metallb,component=speaker"
+        - name: METALLB_ML_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: METALLB_ML_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: memberlist
+              key: secretkey
+        image: metallb/speaker:v0.12
+        imagePullPolicy: Always
+        name: speaker
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            - SYS_ADMIN
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 2
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    component: controller
+  name: controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        image: metallb/controller:v0.12
+        imagePullPolicy: Always
+        name: controller
+        ports:
+        - containerPort: 7472
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0

--- a/kubernetes-networks/metallb-system/namespace.yaml
+++ b/kubernetes-networks/metallb-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+  app.kubernetes.io/name: ingress-nginx
+  app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+  app.kubernetes.io/name: ingress-nginx
+  app.kubernetes.io/instance: ingress-nginx
+  app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: dochombo/otus:web.v1
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket: { port: 8000 }
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      initContainers:
+        - name: init-web
+          image: busybox:1.34.1
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: app
+              mountPath: /app
+          command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7.13-alpine3.15
+COPY templates ./templates
+COPY mysql-operator.py ./mysql-operator.py
+RUN pip install kopf kubernetes pyyaml jinja2
+CMD kopf run /mysql-operator.py

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,124 @@
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and \
+            any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                print(f"job with { jobname }  found,wait untill end")
+                if job.status.succeeded == 1:
+                    print(f"job with { jobname }  success")
+                    job_finished = True
+
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.safe_load(yaml_manifest)
+    return json_manifest
+
+
+def delete_success_jobs(mysql_instance_name):
+    print("start deletion")
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+        jobname = job.metadata.name
+        if (jobname == f"backup-{mysql_instance_name}-job") or \
+                (jobname == f"restore-{mysql_instance_name}-job"):
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname, 'default', propagation_policy='Background')
+
+@kopf.on.field('otus.homework', 'v1', 'mysqls', field='spec.field')
+def update_field(old, new, spec, patch, **kwargs):
+    patch.status['describe'] = 'old:' + old + '; new:' + new
+    return {'info': "spec.field update"}
+
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+def set_status_describe(spec, patch, **kwargs):
+    patch.status['describe'] = 'describe it'
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2', {'name': name, 'storage_size': storage_size})
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+    service = render_template('mysql-service.yml.j2', {'name': name})
+
+    deployment = render_template('mysql-deployment.yml.j2', {'name': name, 'image': image, 'password': password, 'database': database})
+    restore_job = render_template('restore-job.yml.j2', { 'name': name, 'image': image,'password': password, 'database': database})
+
+    # Определяем, что созданные ресурсы являются дочерними к управляемому CustomResource:
+    kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body)  # addopt
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+    kopf.append_owner_reference(restore_job, owner=body)
+    # ^ Таким образом при удалении CR удалятся все, связанные с ним pv,pvc,svc, deployments
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    api.create_persistent_volume(persistent_volume)
+    # Создаем mysql PVC:
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+    # Пытаемся восстановиться из backup
+    try:
+        api = kubernetes.client.BatchV1Api()
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    # Cоздаем PVC  и PV для бэкапов:
+    try:
+        backup_pv = render_template('backup-pv.yml.j2', {'name': name, 'storage_size': storage_size})
+        api = kubernetes.client.CoreV1Api()
+        print(api.create_persistent_volume(backup_pv))
+        api.create_persistent_volume(backup_pv)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    try:
+        backup_pvc = render_template('backup-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+        api = kubernetes.client.CoreV1Api()
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+
+    delete_success_jobs(name)
+
+    # Cоздаем backup job:
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', { 'name': name,'image': image,'password': password,'database': database})
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+    return {'message': "mysql and its children resources deleted"}

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /data/pv-backup/
+ 

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+#        - name: MYSQL_USER
+#          value: {{ mysql_user }}
+#        - name: MYSQL_PASSWORD
+#          value: {{ mysql_password }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/{{ name }}-pv/

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup
+        image: arm64v8/mysql:8.0.29-oracle
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }} < /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/ClusterRoleBinding.yml
+++ b/kubernetes-operators/deploy/ClusterRoleBinding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,13 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword
+  storage_size: 1Gi
+  field: field2
+#  mysql_user: user
+#  mysql_password: password1
+#usless_data: "useless info"

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,59 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced # Данный CRD будер работать в рамках namespace
+  group: otus.homework # Группа, отражается в поле apiVersion CR
+  versions: # Список версий
+    - name: v1
+      served: true # Будет ли обслуживаться API-сервером данная версия
+      storage: true # Версия описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string # Тип данных поля ApiVersion
+            kind:
+              type: string # Тип данных поля kind
+            metadata:
+              type: object # Тип поля metadata
+              properties: # Доступные параметры и их тип данных поля metadata (словарь)
+                name:
+                  type: string
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+                field:
+                  type: string
+#                mysql_user:
+#                  type: string
+#                mysql_password:
+#                  type: string
+              required:
+                - image
+                - database
+                - password
+                - storage_size
+            status:
+              type: object
+              properties:
+                describe:
+                  type: string
+      subresources:
+        status: {}
+  names: # различные форматы имени объекта CR
+    kind: MySQL # kind CR
+    plural: mysqls
+    singular: mysql
+    shortNames:
+    - ms

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "wenger23/mysql-operator:1.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator

--- a/kubernetes-operators/m1_deploy/cr.yml
+++ b/kubernetes-operators/m1_deploy/cr.yml
@@ -1,0 +1,13 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: arm64v8/mysql:8.0.29-oracle
+  database: otus-database
+  password: otuspassword
+  storage_size: 1Gi
+  field: field2
+#  mysql_user: user
+#  mysql_password: password1
+#usless_data: "useless info"

--- a/kubernetes-operators/m1_deploy/crd.yml
+++ b/kubernetes-operators/m1_deploy/crd.yml
@@ -1,0 +1,59 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced # Данный CRD будер работать в рамках namespace
+  group: otus.homework # Группа, отражается в поле apiVersion CR
+  versions: # Список версий
+    - name: v1
+      served: true # Будет ли обслуживаться API-сервером данная версия
+      storage: true # Версия описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string # Тип данных поля ApiVersion
+            kind:
+              type: string # Тип данных поля kind
+            metadata:
+              type: object # Тип поля metadata
+              properties: # Доступные параметры и их тип данных поля metadata (словарь)
+                name:
+                  type: string
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+                field:
+                  type: string
+#                mysql_user:
+#                  type: string
+#                mysql_password:
+#                  type: string
+              required:
+                - image
+                - database
+                - password
+                - storage_size
+            status:
+              type: object
+              properties:
+                describe:
+                  type: string
+      subresources:
+        status: {}
+  names: # различные форматы имени объекта CR
+    kind: MySQL # kind CR
+    plural: mysqls
+    singular: mysql
+    shortNames:
+    - ms


### PR DESCRIPTION
# Выполнено ДЗ № 7

- [ ] Основное ДЗ

Примеры локальных экспеременентов  kubernetes-operators/m1_deploy
```
├── kubernetes-operators
│   ├── build
│   │   ├── Dockerfile
│   │   ├── mysql-operator.py
│   │   └── templates
│   │       ├── backup-job.yml.j2
│   │       ├── backup-pv.yml.j2
│   │       ├── backup-pvc.yml.j2
│   │       ├── mysql-deployment.yml.j2
│   │       ├── mysql-pv.yml.j2
│   │       ├── mysql-pvc.yml.j2
│   │       ├── mysql-service.yml.j2
│   │       └── restore-job.yml.j2
│   ├── deploy
│   │   ├── ClusterRoleBinding.yml
│   │   ├── cr.yml
│   │   ├── crd.yml
│   │   ├── deploy-operator.yml
│   │   ├── role.yml
│   │   └── service-account.yml
│   └── m1_deploy
│       ├── cr.yml
│       └── crd.yml

```
С момента описание схемы выполнения ДЗ произошли изменения:
m1_deploy/crd.yml
```
#The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22.
#https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition

```

Отладка контроллер - при использовании для примера приложенного к домашнему заданию контроллера
были исправлены следующее

```
#load() missing 1 required positional argument: 'Loader'", 'subrefs
- json_manifest = yaml.load(yaml_manifest)
+ json_manifest = yaml.safe_load(sys.stdin)
```

```
#'это не обязательно, по факту в шаблоне указано явно, как задел а будущее
- backup_pv = render_template('backup-pv.yml.j2', {'name': name})
+ backup_pv = render_template('backup-pv.yml.j2', {'name': name, 'storage_size': storage_size})

- backup_pvc = render_template('backup-pvc.yml.j2', {'name': name)
+ backup_pvc = render_template('backup-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
```

Так как домашнее задание выполняется на m1, возникли сложности и образом
mysql:5.7, в процессе локальной отладки использовался arm64v8/mysql:8.0.29-oracle.

build/templates/mysql-deployment.yml.j2
```
- args:
- - "--ignore-db-dir=lost+found"
```
Вероятнее всего при автотестах не заработает, ограниченное свободное время
на выполнение ДЗ - не позволит сделать его в полном обьеме, так что частично
придется ограничиться тестовыми пояснениями

Еще одной неприятной и не решенной проблемой - оказалась необходимость руками
удалять mysql-instance-pv.
```
[2022-05-18 19:51:42,187] kopf.objects         [WARNING ] [default/mysql-instance] Patching failed with inconsistencies: (('remove', ('status',), {'kopf': {'progress': 
{'mysql_on_create': {'started': '2022-05-18T16:51:42.120697', 'stopped': None, 'delayed': '2022-05-18T16:52:42.175612', 'purpose': 'create', 'retries': 1, 'success': 
False, 'failure': False, 'message': '(409)\nReason: Conflict\nHTTP response headers: HTTPHeaderDict({\'Audit-Id\': \'70b1402d-5889-4c81-8ae8-d4e078b58a5c\', \'Cache-Control\': \'no-cache, private\', \'Content-Type\': 
\'application/json\', \'X-Kubernetes-Pf-Flowschema-Uid\': \'b41bfecc-8ad1-4996-ab2d-bc0acd241368\', \'X-Kubernetes-Pf-Prioritylevel-Uid\': \'dfab7d6d-35c9-4382-bf9b-a48d4bc1daee\', \'Date\': 
\'Wed, 18 May 2022 16:51:42 GMT\', \'Content-Length\': \'238\'})\nHTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"persistentvolumes \\"mysql-instance-pv\\" already exists",
"reason":"AlreadyExists","details":{"name":"mysql-instance-pv","kind":"persistentvolumes"},"code":409}\n\n', 'subrefs': None}}}}, None),)

```

- [ ] Задание со * (1)

- Исправить контроллер, чтобы он писал в status subresource
- Описать изменения в README.md (показать код, объяснить, что он делает)
- В README показать, что в status происходит запись
- Например, при успешном создании mysql-instance, kubectl describe
  mysqls.otus.homework mysql-instance может показывать:

m1_deploy/crd.yml
``` 
            status:
              type: object
              properties:
                describe:
                  type: string
      subresources:
        status: {}
```
~/Library/Python/3.8/bin/kopf run mysql-operator.py
```
@kopf.on.create('otus.homework', 'v1', 'mysqls')
def set_status_describe(spec, patch, **kwargs):
    patch.status['describe'] = 'describe it'
 ```

kubectl describe mysqls.otus.homework mysql-instance

```
Spec:
  Database:      otus-database
  Image:         arm64v8/mysql:8.0.29-oracle
  Password:      otuspassword
  storage_size:  1Gi
Status:
  Describe:  describe it
Events:
  Type    Reason   Age   From  Message
  ----    ------   ----  ----  -------
  Normal  Logging  23s   kopf  Handler 'set_status_describe' succeeded.
  Normal  Logging  23s   kopf  Creation is processed: 2 succeeded; 0 failed.
  Normal  Logging  23s   kopf  Handler 'mysql_on_create' succeeded.
```

- [ ] Задание со * (2)
  В задании предложено реализовать изменений пароля (в случае с предложенным в задании вариантом
  дополнительно надо было бы создать шаблон job и выполнить похожие
  действия как описаны в mysql_on_create)
  Реализация была сознательно упрощена, в случае изменения
  spec.field записывается status.describe:

m1_deploy/cr.yml
```
  field: field2
```
m1_deploy/crd.yml
```
                field:
                  type: string
```
kubectl describe mysqls.otus.homework mysql-instance
```
Status:
  Describe:  old:field1; new:field2
Events:
  Type    Reason   Age   From  Message
  ----    ------   ----  ----  -------
  Normal  Logging  16s   kopf  Updating is processed: 1 succeeded; 0 failed.
  Normal  Logging  16s   kopf  Handler 'update_field/spec.field' succeeded.
```

## PR checklist:
- [ kubernetes-operators ] Выставлен label с темой домашнего задания


